### PR TITLE
Replace functionality depreciated in numpy with new implementation

### DIFF
--- a/dqn_cartpole.py
+++ b/dqn_cartpole.py
@@ -120,7 +120,7 @@ while True:
     action = env.action_space.sample()
   else:
     # exploit
-    state_a = np.array([state], copy=False)
+    state_a = np.asarray([state])
     state_v = torch.tensor(state_a).to(device)
     q_vals_v = net(state_v)
     _, act_v = torch.max(q_vals_v, dim=1)

--- a/dqn_gym.py
+++ b/dqn_gym.py
@@ -138,7 +138,7 @@ while True:
         action = env.action_space.sample()
     else:
         # exploit
-        state_a = np.array([state], copy=False)
+        state_a = np.asarray([state])
         state_v = torch.tensor(state_a).to(device)
         q_vals_v = net(state_v)
         _, act_v = torch.max(q_vals_v, dim=1)


### PR DESCRIPTION
Hi,
I noticed that running the code with recent versions of Numpy results in the following error:
```
File "/Users/tday/uni/comp3702/assignments/a3/tutorial11/dqn_gym.py", line 141, in <module>
    state_a = np.array([state], copy=False)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```

This is due to the depreciated usage of the copy keyword in Numpy 2.0 (see [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword))

This patch replaces this usage with Numpy's suggested workaround, the `asarray` method.