### PR TITLE
Fixed minor typo in README.md for terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The DQN network structure is controlled by command line argument `-n `
 It also saves the trained model in [saved_models/](saved_models/).
 
     python dqn_gym.py -e CartPole-v1 -n two-hidden
-    python dqn_bym.py -e CartPole-v1 -n duelling-dqn
+    python dqn_gym.py -e CartPole-v1 -n duelling-dqn
 
 `CartPole-v1` is much more difficult to solve than `CartPole-v0`, but both `d` and `dd` options should do it, although the number of frames may vary greatly.
 The solved threshold is 475 (which means the R100 needs to reach 475). Both of them also use soft updates of the target network, rather than full update every 1k frames.


### PR DESCRIPTION
Minor, but one of my students was confused on this so here's the fix.